### PR TITLE
Fix typo for the extensions folder path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ But if you want to do it manually, you can:
 
 0. Clone this project into your machine.
 1. Move the Hide_Activities@shay.shayel.org directory into
-~/.local/share/gnome-shell/extenstions/
+~/.local/share/gnome-shell/extensions/
 2. Press Alt+F2, and in the window that opens, type 'r' and enter to
 restart GNOME shell.
 3. Enable the extension by using gnome-tweak-tool, or from the [web


### PR DESCRIPTION
There was an extra `t` in the word `extensions`